### PR TITLE
fix: CI deployment failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,9 +6,9 @@ on:
       - main
 
 jobs:
-  deploy:
+  test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10  # Set a timeout for the job
+    timeout-minutes: 30  # Set a timeout for the job
 
     steps:
       - name: Checkout code
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest /tests
+          pytest /tests --maxfail=1 --disable-warnings -v
 
       - name: Debugging
         run: |


### PR DESCRIPTION
## Description
- Updates the ci.yaml file for longer timeout and verbose testing

## Related Task
[HNG12 Stage 2 Task](https://hng12.slack.com/archives/D08A8JGUN15/p1739276303633969)

## Testing
- Tested the application locally with the updated runtime version.

## Notes
- [Deployment URL](http://34.171.156.87)